### PR TITLE
Fix: Add missing event name filter in SQL statements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,7 @@
     "require-dev": {
         "captainhook/captainhook": "^5.23",
         "friendsofphp/php-cs-fixer": "^3.58",
-        "mockery/mockery": "^1.6",
-        "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
-        "phpstan/phpstan-mockery": "^2.0",
         "phpunit/phpunit": "^12.1",
         "rector/rector": "^2.0",
         "rregeer/phpunit-coverage-check": "^0.3.1",
@@ -50,10 +47,7 @@
         }
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "phpstan/extension-installer": true
-        }
+        "sort-packages": true
     },
     "scripts": {
         "coverage": "vendor/bin/coverage-check var/coverage/clover.xml 65",

--- a/src/DoctrineDbalRdbmsEventStoreRepository.php
+++ b/src/DoctrineDbalRdbmsEventStoreRepository.php
@@ -55,7 +55,9 @@ final readonly class DoctrineDbalRdbmsEventStoreRepository implements RdbmsEvent
                 $eventStoreSchema->eventIdFieldName,
                 $eventStoreRelationSchema->eventIdFieldName,
             ))
+            ->where(sprintf('es.%s IN(:eventNames)', $eventStoreSchema->eventNameFieldName))
             ->andWhere(sprintf('esr.%s IN(:domainIds)', $eventStoreRelationSchema->domainIdFieldName))
+            ->setParameter('eventNames', $eventNames, ArrayParameterType::STRING)
             ->setParameter('domainIds', $domainIds, ArrayParameterType::STRING)
             ->orderBy(sprintf('es.%s', $eventStoreSchema->appliedAtFieldName), 'asc')
             ->executeQuery()
@@ -91,7 +93,9 @@ final readonly class DoctrineDbalRdbmsEventStoreRepository implements RdbmsEvent
                 $eventStoreSchema->eventIdFieldName,
                 $eventStoreRelationSchema->eventIdFieldName,
             ))
+            ->where(sprintf('es.%s IN(:eventNames)', $eventStoreSchema->eventNameFieldName))
             ->andWhere(sprintf('esr.%s IN(:domainIds)', $eventStoreRelationSchema->domainIdFieldName))
+            ->setParameter('eventNames', $eventNames, ArrayParameterType::STRING)
             ->setParameter('domainIds', $domainIds, ArrayParameterType::STRING)
             ->orderBy(sprintf('es.%s', $eventStoreSchema->appliedAtFieldName), 'desc')
             ->setMaxResults(1)

--- a/tests/DoctrineDbalRdbmsEventStoreRepositoryTest.php
+++ b/tests/DoctrineDbalRdbmsEventStoreRepositoryTest.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace Gember\RdbmsEventStoreDoctrineDbal\Test;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
 use Gember\EventSourcing\EventStore\Rdbms\RdbmsEvent;
 use Gember\RdbmsEventStoreDoctrineDbal\DoctrineDbalRdbmsEventFactory;
 use Gember\RdbmsEventStoreDoctrineDbal\DoctrineDbalRdbmsEventStoreRepository;
 use Gember\RdbmsEventStoreDoctrineDbal\TableSchema\TableSchemaFactory;
-use Mockery;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Override;
@@ -24,9 +20,6 @@ use DateTimeImmutable;
  */
 final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
-    private MockInterface&Result $result;
     private DoctrineDbalRdbmsEventStoreRepository $repository;
 
     #[Override]
@@ -34,20 +27,8 @@ final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
     {
         parent::setUp();
 
-        $connection = Mockery::mock(Connection::class);
-        $queryBuilder = Mockery::mock(QueryBuilder::class);
-
-        $this->result = Mockery::mock(Result::class);
-
-        $connection->allows('createQueryBuilder')->andReturn($queryBuilder);
-        $queryBuilder->allows('select')->andReturn($queryBuilder);
-        $queryBuilder->allows('from')->andReturn($queryBuilder);
-        $queryBuilder->allows('join')->andReturn($queryBuilder);
-        $queryBuilder->allows('andWhere')->andReturn($queryBuilder);
-        $queryBuilder->allows('setParameter')->andReturn($queryBuilder);
-        $queryBuilder->allows('orderBy')->andReturn($queryBuilder);
-        $queryBuilder->allows('setMaxResults')->andReturn($queryBuilder);
-        $queryBuilder->allows('executeQuery')->andReturn($this->result);
+        $connection = DriverManager::getConnection((new DsnParser())->parse('pdo-sqlite:///:memory:'));
+        $connection->executeStatement((string) file_get_contents(__DIR__ . '/schema.sql'));
 
         $this->repository = new DoctrineDbalRdbmsEventStoreRepository(
             $connection,
@@ -55,42 +36,50 @@ final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
             TableSchemaFactory::createDefaultEventStoreRelation(),
             new DoctrineDbalRdbmsEventFactory(),
         );
+
+        $this->repository->saveEvents([
+            new RdbmsEvent(
+                '63129dc3-4a27-4242-a8bc-6f79636a6fa9',
+                ['6ae07469-0f43-4f33-979b-c783b6824ce0', '0c1ff409-a4be-42f1-90dd-5d7b0130a426'],
+                'event_name',
+                '{"data":"some"}',
+                ['metadata' => 'some'],
+                new DateTimeImmutable('2024-12-06 12:05:04.456344'),
+            ),
+            new RdbmsEvent(
+                '707678d3-c91d-4864-9729-555b22496853',
+                ['0e76f2bd-2aae-44a4-b149-740c080e4d05'],
+                'event_name',
+                '{"data":"another_event"}',
+                ['metadata' => 'another_event'],
+                new DateTimeImmutable('2024-12-01 13:16:24.467784'),
+            ),
+            new RdbmsEvent(
+                '7ac51abe-9176-4794-8246-24b75c2ba914',
+                ['0c1ff409-a4be-42f1-90dd-5d7b0130a426'],
+                'event_name_2',
+                '{"data":"another"}',
+                ['metadata' => 'another'],
+                new DateTimeImmutable('2024-12-04 13:15:26.755844'),
+            ),
+            new RdbmsEvent(
+                'd404e3c1-c782-4115-b8ec-d8cb341d87cb',
+                ['6ae07469-0f43-4f33-979b-c783b6824ce0'],
+                'event_name_3',
+                '{"data":"another"}',
+                ['metadata' => 'another3'],
+                new DateTimeImmutable('2024-12-02 13:16:24.467784'),
+            ),
+        ]);
     }
 
     #[Test]
     public function itShouldGetEvents(): void
     {
-        $this->result->expects('fetchAllAssociative')->andReturn([
-            [
-                'eventId' => '63129dc3-4a27-4242-a8bc-6f79636a6fa9',
-                'eventName'=> 'event_name',
-                'payload' => '{"data":"some"}',
-                'metadata' => '{"metadata":"some"}',
-                'appliedAt' => '2024-12-03 12:05:04.456344',
-                'domainId' => '6ae07469-0f43-4f33-979b-c783b6824ce0',
-            ],
-            [
-                'eventId' => '63129dc3-4a27-4242-a8bc-6f79636a6fa9',
-                'eventName'=> 'event_name',
-                'payload' => '{"data":"some"}',
-                'metadata' => '{"metadata":"some"}',
-                'appliedAt' => '2024-12-03 12:05:04.456344',
-                'domainId' => '0c1ff409-a4be-42f1-90dd-5d7b0130a426',
-            ],
-            [
-                'eventId' => '7ac51abe-9176-4794-8246-24b75c2ba914',
-                'eventName'=> 'event_name_2',
-                'payload' => '{"data":"another"}',
-                'metadata' => '{"metadata":"another"}',
-                'appliedAt' => '2024-12-04 13:15:26.755844',
-                'domainId' => '6ae07469-0f43-4f33-979b-c783b6824ce0',
-            ],
-        ]);
-
         $events = $this->repository->getEvents(
             [
-                '072fd355-bd4e-423b-a7ba-fb1a77e32d7c',
-                '60a8635c-c769-4d19-8cae-a9571401848f',
+                '0c1ff409-a4be-42f1-90dd-5d7b0130a426',
+                '6ae07469-0f43-4f33-979b-c783b6824ce0',
             ],
             [
                 'event_name',
@@ -100,25 +89,25 @@ final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
 
         self::assertEquals([
             new RdbmsEvent(
-                '63129dc3-4a27-4242-a8bc-6f79636a6fa9',
-                [
-                    '6ae07469-0f43-4f33-979b-c783b6824ce0',
-                    '0c1ff409-a4be-42f1-90dd-5d7b0130a426',
-                ],
-                'event_name',
-                '{"data":"some"}',
-                ['metadata' => 'some'],
-                new DateTimeImmutable('2024-12-03 12:05:04.456344'),
-            ),
-            new RdbmsEvent(
                 '7ac51abe-9176-4794-8246-24b75c2ba914',
                 [
-                    '6ae07469-0f43-4f33-979b-c783b6824ce0',
+                    '0c1ff409-a4be-42f1-90dd-5d7b0130a426',
                 ],
                 'event_name_2',
                 '{"data":"another"}',
                 ['metadata' => 'another'],
                 new DateTimeImmutable('2024-12-04 13:15:26.755844'),
+            ),
+            new RdbmsEvent(
+                '63129dc3-4a27-4242-a8bc-6f79636a6fa9',
+                [
+                    '0c1ff409-a4be-42f1-90dd-5d7b0130a426',
+                    '6ae07469-0f43-4f33-979b-c783b6824ce0',
+                ],
+                'event_name',
+                '{"data":"some"}',
+                ['metadata' => 'some'],
+                new DateTimeImmutable('2024-12-06 12:05:04.456344'),
             ),
         ], $events);
     }
@@ -126,8 +115,6 @@ final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
     #[Test]
     public function itShouldReturnNullWhenGetLastEventIdPersistedIsNotFound(): void
     {
-        $this->result->expects('fetchFirstColumn')->andReturn([]);
-
         $lastEventIdPersisted = $this->repository->getLastEventIdPersisted(
             [
                 '072fd355-bd4e-423b-a7ba-fb1a77e32d7c',
@@ -145,12 +132,10 @@ final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
     #[Test]
     public function itShouldGetLastEventIdPersisted(): void
     {
-        $this->result->expects('fetchFirstColumn')->andReturn(['id' => 'dc99db45-1d1f-4d9d-b52a-83b1cabad89d']);
-
         $lastEventIdPersisted = $this->repository->getLastEventIdPersisted(
             [
-                '072fd355-bd4e-423b-a7ba-fb1a77e32d7c',
-                '60a8635c-c769-4d19-8cae-a9571401848f',
+                '0c1ff409-a4be-42f1-90dd-5d7b0130a426',
+                '6ae07469-0f43-4f33-979b-c783b6824ce0',
             ],
             [
                 'event_name',
@@ -158,6 +143,6 @@ final class DoctrineDbalRdbmsEventStoreRepositoryTest extends TestCase
             ],
         );
 
-        self::assertSame('dc99db45-1d1f-4d9d-b52a-83b1cabad89d', $lastEventIdPersisted);
+        self::assertSame('63129dc3-4a27-4242-a8bc-6f79636a6fa9', $lastEventIdPersisted);
     }
 }

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `event_store` (
+  `id` varchar(50) NOT NULL,
+  `event_name` varchar(100) NOT NULL,
+  `payload` json NOT NULL,
+  `metadata` json NOT NULL,
+  `applied_at` timestamp(6) NOT NULL
+);
+
+CREATE TABLE `event_store_relation` (
+  `event_id` varchar(50) NOT NULL,
+  `domain_id` varchar(50) NOT NULL
+);


### PR DESCRIPTION
# Description
Even though events which are unknown (do not have an apply* method in the domain context) will just be ignored, it should not load those, the event names are input to be used to filter on :)